### PR TITLE
Update ttt.js

### DIFF
--- a/ttt.js
+++ b/ttt.js
@@ -136,6 +136,12 @@ function TicTacToeAppCtrl($scope) {
    * @private
    */
   this.playAction = false;
+  
+  /**
+   * @type {string}
+   * @private
+   */
+  this.joinSessionId = (new URLSearchParams(window.location.search)).get('sessionId');
 
   window['__onGCastApiAvailable'] = (function(loaded, errorInfo) {
     if (loaded) {
@@ -330,9 +336,14 @@ TicTacToeAppCtrl.prototype.safeApply_ = function() {
  * @private
  */
 TicTacToeAppCtrl.prototype.launch_ = function() {
-  this.appendMessage_('launching...');
-  chrome.cast.requestSession(this.sessionListener_.bind(this),
-    this.onError_.bind(this));
+  if (this.joinSessionId) {
+    this.appendMessage_('joining ' + this.joinSessionId + ' ...' );
+    chrome.cast.requestSessionById(this.joinSessionId);
+  } else {
+    this.appendMessage_('launching...');
+    chrome.cast.requestSession(this.sessionListener_.bind(this),
+      this.onError_.bind(this));
+  }
 };
 
 /**


### PR DESCRIPTION
Connecting a second player didn't work (anymore), the receiver app on the Chromecast relaunches when a second player tries to join. An existing cast session can be joined by using requestSessionId with the existing session id as an argument. This modification allows a second player to join an existing session by supplying the session id via the query string (e.g. https://[YOUR_SERVER_LOCATION]/ttt/?sessionId=[EXISTING_SESSION_ID]).

Unfortunately joining an existing session only works using the Chrome browser on a desktop. Joining an existing session from the Chrome browser on Android still doesn't seem to work.